### PR TITLE
Update to Dockerode 2.0.6

### DIFF
--- a/package.js
+++ b/package.js
@@ -2,12 +2,12 @@
 Package.describe({
   name: "ongoworks:dockerode",
   summary: "Docker remote API. Wraps the dockerode package for Meteor.",
-  version: "0.1.3",
+  version: "0.1.4",
   git: "https://github.com/ongoworks/meteor-dockerode"
 });
 
 Npm.depends({
-  "dockerode": "2.0.4"
+  "dockerode": "2.0.6"
 });
 
 Package.on_use(function (api) {


### PR DESCRIPTION
Thanks for wrapping it.

Need newer Dockerrode which support passing STDIN to exec:
https://github.com/apocas/dockerode/commit/a97f22565baeb8cf58b4a367918843f982a2d0e2

Please merge and update the package on atmosphere.